### PR TITLE
Using StringBuilder instead of String object

### DIFF
--- a/DevTest1/DevTest1/Controllers/HomeController.vb
+++ b/DevTest1/DevTest1/Controllers/HomeController.vb
@@ -9,19 +9,16 @@
 
     Function CsvReport() As ActionResult
 
+        Dim csv As StringBuilder = New StringBuilder()
+        csv.Append(String.Format("{0},{1},{2}", "Company", "Name", "EmailAddress") & Environment.NewLine)
+
         Dim list As List(Of Customer) = Customer.CreateList()
 
-        Dim csvHeader As String = "Company, Name, EmailAddress" & vbCr
-        Dim csvBody As String = ""
-
-        'build body
         For Each c As Customer In list
-            csvBody &= c.Company & ", "
-            csvBody &= c.Name & ", "
-            csvBody &= c.EmailAddress & vbCr
+            csv.Append(String.Format("{0},{1},{2}", c.Company, c.Name, c.EmailAddress) & Environment.NewLine)
         Next
 
-        ViewBag.CsvReport = csvHeader & csvBody
+        ViewBag.CsvReport = csv
 
         Return View()
 


### PR DESCRIPTION
using StringBuilder as we are concatenating string object in a loop using &= operator . Use of string object in large amount of string manuplication is less efficent. String Builder is more efficient in this scenario.

String object are immutable, which means once they are created they cannot be changed. When we use one of the methods in string class , we create a new String object

Whereas StringBuilder arre mutable class, which means when concatenated any text to a vriable it allows us to modify the orignial value without creating new method.