### PR TITLE
as296426 - devtest-1 - Made changes to fix performance issue.

### DIFF
--- a/DevTest1/DevTest1/Controllers/HomeController.vb
+++ b/DevTest1/DevTest1/Controllers/HomeController.vb
@@ -10,19 +10,15 @@
     Function CsvReport() As ActionResult
 
         Dim list As List(Of Customer) = Customer.CreateList()
-
         Dim csvHeader As String = "Company, Name, EmailAddress" & vbCr
-        Dim csvBody As String = ""
-
+        Dim csvBody As New StringBuilder
         'build body
         For Each c As Customer In list
-            csvBody &= c.Company & ", "
-            csvBody &= c.Name & ", "
-            csvBody &= c.EmailAddress & vbCr
+            csvBody.Append(c.Company & ", ")
+            csvBody.Append(c.Name & ", ")
+            csvBody.Append(c.EmailAddress & vbCr)
         Next
-
-        ViewBag.CsvReport = csvHeader & csvBody
-
+        ViewBag.CsvReport = csvHeader & csvBody.ToString()
         Return View()
 
     End Function


### PR DESCRIPTION
Root Cause :- It is performing poor because we were using string to add the item from list and
display on HTML. String always create new instance when we add new item to string which eventually decrease the performance.

Stringbuilder :- Doesnt create new instance when we add new item to string builder.

String was good option if we have only one item to add but here we are getting many items from list and adding one by one which eventually creating instance everytime and performing poor.