### PR TITLE
Explanation and code change

### DIFF
--- a/DevTest1/DevTest1/Controllers/HomeController.vb
+++ b/DevTest1/DevTest1/Controllers/HomeController.vb
@@ -12,15 +12,15 @@
         Dim list As List(Of Customer) = Customer.CreateList()
 
         Dim csvHeader As String = "Company, Name, EmailAddress" & vbCr
-        Dim csvBody As String = ""
-
+        Dim sb As New System.Text.StringBuilder
         'build body
         For Each c As Customer In list
-            csvBody &= c.Company & ", "
-            csvBody &= c.Name & ", "
-            csvBody &= c.EmailAddress & vbCr
+            'csvBody &= c.Company & ", "
+            'csvBody &= c.Name & ", "
+            'csvBody &= c.EmailAddress & vbCr
+            sb.AppendLine($"{c.Company}, {c.Name}, {c.EmailAddress}")
         Next
-
+        Dim csvBody As String = sb.ToString()
         ViewBag.CsvReport = csvHeader & csvBody
 
         Return View()

--- a/README.md
+++ b/README.md
@@ -15,3 +15,14 @@ In your pull request
 ## Constraints
 * Do not change the Customers class.
 * Do not use any additional libraries (no additional nuget packages).
+
+
+## Explanation
+* In the HomeController.vb file, there is a For Each loop over the list of customers.
+* In the code provided, the csvBody string variable is being concatenated 3 times per iteration.
+* Since, in the CLR, strings are immutable, this is adding a new string object to the heap
+    * 3 times per iteration. This is a very large memory and performance problem.
+* Using a StringBuilder object is a much better solution because it allows you to have a mutable string object.
+    * This allows you to append values to a string without adding new memory allocations to the heap.
+    * Once the appending is done, the StringBuilder.ToString() method returns a string (object) value.
+* Thus, using a StringBuilder object in lieu of repeatedly concatenting a string should decrease the run time.


### PR DESCRIPTION
## Explanation
* In the HomeController.vb file, there is a For Each loop over the list of customers.
* In the code provided, the csvBody string variable is being concatenated 3 times per iteration.
* Since, in the CLR, strings are immutable, this is adding a new string object to the heap
    * 3 times per iteration. This is a very large memory and performance problem.
* Using a StringBuilder object is a much better solution because it allows you to have a mutable string object.
    * This allows you to append values to a string without adding new memory allocations to the heap.
    * Once the appending is done, the StringBuilder.ToString() method returns a string (object) value.
* Thus, using a StringBuilder object in lieu of repeatedly concatenting a string should decrease the run time.